### PR TITLE
홈 조회 시 저장한 뉴스에 관련된 숏스는 필터링 하는 기능 수정

### DIFF
--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/member/membernews/MemberNewsRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/member/membernews/MemberNewsRepository.kt
@@ -13,4 +13,6 @@ interface MemberNewsRepository : JpaRepository<MemberNews, Long> {
     fun existsByMemberAndNews(member: Member, news: News): Boolean
 
     fun countAllByMember(member: Member): Int
+
+    fun findAllByMember(member: Member): List<MemberNews>
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/member/membernewscard/dtomapper/MemberNewsCardResponse.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/member/membernewscard/dtomapper/MemberNewsCardResponse.kt
@@ -2,13 +2,15 @@ package com.mashup.shorts.domain.member.membernewscard.dtomapper
 
 import java.time.LocalDateTime
 import com.mashup.shorts.domain.newscard.NewsCard
+import com.querydsl.core.annotations.QueryProjection
 
-data class RetrieveAllNewsCardResponseMapper(
+data class RetrieveAllNewsCardResponseMapper @QueryProjection constructor(
     var id: Long,
     var keywords: String,
     var category: String,
     var crawledDateTime: LocalDateTime,
 ) {
+
     companion object {
         fun persistenceToResponseForm(newsCards: List<NewsCard>): List<RetrieveAllNewsCardResponseMapper> {
             return newsCards.map {

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
@@ -1,0 +1,14 @@
+package com.mashup.shorts.domain.newscard
+
+import com.mashup.shorts.domain.member.membernewscard.dtomapper.RetrieveAllNewsCardResponseMapper
+
+interface NewsCardQueryDSLRepository {
+
+    fun findNewsCardsByMemberCategoryAndCursorId(
+        filteredNewsIds: List<String>,
+        cursorId: Long,
+        size: Int,
+        categories: List<Long>,
+    ): List<RetrieveAllNewsCardResponseMapper>
+
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
@@ -4,11 +4,11 @@ import com.mashup.shorts.domain.member.membernewscard.dtomapper.RetrieveAllNewsC
 
 interface NewsCardQueryDSLRepository {
 
-    fun findNewsCardsByMemberCategoryAndCursorId(
-        filteredNewsIds: List<String>,
+    fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
+        filteredNewsIds: List<Long>,
         cursorId: Long,
-        size: Int,
         categories: List<Long>,
+        size: Int,
     ): List<RetrieveAllNewsCardResponseMapper>
 
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
@@ -1,0 +1,47 @@
+package com.mashup.shorts.domain.newscard
+
+import java.time.LocalDateTime
+import org.springframework.stereotype.Repository
+import com.mashup.shorts.domain.member.membernewscard.dtomapper.QRetrieveAllNewsCardResponseMapper
+import com.mashup.shorts.domain.member.membernewscard.dtomapper.RetrieveAllNewsCardResponseMapper
+import com.mashup.shorts.domain.newscard.QNewsCard.newsCard
+import com.querydsl.core.types.Predicate
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+@Repository
+class NewsCardQueryDSLRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : NewsCardQueryDSLRepository {
+    override fun findNewsCardsByMemberCategoryAndCursorId(
+        filteredNewsIds: List<String>,
+        cursorId: Long,
+        size: Int,
+        categories: List<Long>,
+    ): List<RetrieveAllNewsCardResponseMapper> {
+        return queryFactory
+            .select(
+                QRetrieveAllNewsCardResponseMapper(
+                    newsCard.id,
+                    newsCard.keywords,
+                    newsCard.category.name.stringValue(),
+                    newsCard.createdAt
+                )
+            )
+            .from(newsCard)
+            .where(newsCard.id.gt(cursorId))
+            .where(newsCard.multipleNews.notIn(filteredNewsIds))
+            .where(categoryCondition(categories))
+            .where(newsCard.createdAt.loe(LocalDateTime.now()))
+            .orderBy(newsCard.id.asc())
+            .limit(size.toLong())
+            .fetch()
+    }
+
+    private fun categoryCondition(categories: List<Long>): Predicate? {
+        return if (categories.isNotEmpty()) {
+            newsCard.category.id.`in`(categories)
+        } else {
+            null
+        }
+    }
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
@@ -12,11 +12,11 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 class NewsCardQueryDSLRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : NewsCardQueryDSLRepository {
-    override fun findNewsCardsByMemberCategoryAndCursorId(
-        filteredNewsIds: List<String>,
+    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
+        filteredNewsIds: List<Long>,
         cursorId: Long,
-        size: Int,
         categories: List<Long>,
+        size: Int,
     ): List<RetrieveAllNewsCardResponseMapper> {
         return queryFactory
             .select(
@@ -29,7 +29,7 @@ class NewsCardQueryDSLRepositoryImpl(
             )
             .from(newsCard)
             .where(newsCard.id.gt(cursorId))
-            .where(newsCard.multipleNews.notIn(filteredNewsIds))
+            .where(newsCard.multipleNews.notIn(filteredNewsIds.toString()))
             .where(categoryCondition(categories))
             .where(newsCard.createdAt.loe(LocalDateTime.now()))
             .orderBy(newsCard.id.asc())

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardRepository.kt
@@ -1,11 +1,9 @@
 package com.mashup.shorts.domain.newscard
 
-import java.time.LocalDate
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
-import com.mashup.shorts.domain.category.Category
 
 @Repository
 interface NewsCardRepository : JpaRepository<NewsCard, Long> {
@@ -13,32 +11,34 @@ interface NewsCardRepository : JpaRepository<NewsCard, Long> {
     @Query(
         "SELECT * FROM news_card " +
             "WHERE id > :cursorId " +
-            "AND created_at BETWEEN :targetDate AND (:targetDate + INTERVAL + :targetHour HOUR) " +
+            "AND multiple_news not in (:filteredNewsIds) " +
+            "AND created_at < NOW() " +
             "ORDER BY id ASC " +
-            "LIMIT :size", nativeQuery = true
+            "LIMIT :size",
+        nativeQuery = true
     )
-    fun findNewsCardsByTargetTimeAndAndMemberCategoryAndCursorId(
-        @Param("targetDate") targetDate: LocalDate,
-        @Param("targetHour") targetHour: Int,
+    fun retrieveNewsCardByMemberNoCategory(
+        @Param("filteredNewsIds") filteredNewsIds: List<Long>,
         @Param("cursorId") cursorId: Long,
         @Param("size") size: Int,
     ): List<NewsCard>
 
     @Query(
         "SELECT * FROM news_card " +
-            "WHERE id > :cursorId " +
-            "AND created_at BETWEEN :targetDate AND (:targetDate + INTERVAL + :targetHour HOUR) " +
-            "AND category_id in :categories " +
-            "AND multiple_news not in :filteredNewsIds " +
-            "ORDER BY id ASC " +
-            "LIMIT :size", nativeQuery = true
+            "JOIN category on category.id = news_card.category.id " +
+            "WHERE news_card.id > :cursorId " +
+            "AND news_card.multiple_news not in (:filteredNewsIds) " +
+            "AND news_card.category in (:categories) " +
+            "AND news_card.created_at < NOW() " +
+            "ORDER BY news_card.id ASC " +
+            "LIMIT :size",
+        nativeQuery = true
     )
-    fun findNewsCardsByTargetTimeAndAndMemberCategoryAndCursorIdAndCategory(
-        @Param("targetDate") targetDate: LocalDate,
-        @Param("targetHour") targetHour: Int,
+    fun retrieveNewsCardByMemberAndCategory(
         @Param("filteredNewsIds") filteredNewsIds: List<Long>,
         @Param("cursorId") cursorId: Long,
-        @Param("size") size: Int,
         @Param("categories") categories: List<Long>,
+        @Param("size") size: Int,
     ): List<NewsCard>
+
 }


### PR DESCRIPTION
## 변경 점

기존 로직은 MemberNews가 아닌 MeberNewsCard에 포함된 뉴스 카드를 필터링 했으나

MemberNews(오래 저장할 숏스(뉴스))를 바탕으로 필터링 할 수 있도록 수정

## 좀 이상한 점

QueryDSL로 해결하려 했으나 NewsCard.multipleNews가 StringPath타입으로, not In 쿼리에 문제가 발생 예상한 바로는 다음과 같음

![image](https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/60564431/afe9013f-4666-48f7-98b0-ff46bd1ec4cb)

하지만 not in 쿼리가 정상적으로 수행되려면 다음과 같이 쿼리가 되어야함

![image](https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/60564431/3b410676-1ab5-4964-a662-280485a07a47)

---

도저히 해결방법을 찾을 수가 없어서 아래와 같은NativeQuery로 작성함

```kotlin
@Repository
interface NewsCardRepository : JpaRepository<NewsCard, Long> {

    @Query(
        "SELECT * FROM news_card " +
            "WHERE id > :cursorId " +
            "AND multiple_news not in (:filteredNewsIds) " +
            "AND created_at < NOW() " +
            "ORDER BY id ASC " +
            "LIMIT :size",
        nativeQuery = true
    )
    fun retrieveNewsCardByMemberNoCategory(
        @Param("filteredNewsIds") filteredNewsIds: List<Long>,
        @Param("cursorId") cursorId: Long,
        @Param("size") size: Int,
    ): List<NewsCard>

    @Query(
        "SELECT * FROM news_card " +
            "JOIN category on category.id = news_card.category.id " +
            "WHERE news_card.id > :cursorId " +
            "AND news_card.multiple_news not in (:filteredNewsIds) " +
            "AND news_card.category in (:categories) " +
            "AND news_card.created_at < NOW() " +
            "ORDER BY news_card.id ASC " +
            "LIMIT :size",
        nativeQuery = true
    )
    fun retrieveNewsCardByMemberAndCategory(
        @Param("filteredNewsIds") filteredNewsIds: List<Long>,
        @Param("cursorId") cursorId: Long,
        @Param("categories") categories: List<Long>,
        @Param("size") size: Int,
    ): List<NewsCard>

}
```