### PR TITLE
홈 조회 시 카테고리가 올바르게 지정되지 않던 버그 수정 / 조회 시 날짜 조건문 추가 + 커서 비교 구문 변경

### DIFF
--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
@@ -29,7 +29,7 @@ class MemberNewsCardRetrieve(
         val newsCards = newsCardRepository.findNewsCardsByMemberFilteredNewsIdsAndCursorId(
             filteredNewsIds = filteredNewsIds,
             cursorId = cursorId,
-            categories = memberCategories.map { it.id },
+            categories = memberCategories.map { it.category.id },
             size = size
         )
 

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
@@ -38,9 +38,6 @@ class MemberNewsCardRetrieve(
             .withSecond(59)
             .withNano(59)
 
-        println("startDateTime = ${startDateTime}")
-        println("endDateTime = ${endDateTime}")
-
         val newsCards = newsCardRepository.findNewsCardsByMemberFilteredNewsIdsAndCursorId(
             filteredNewsIds = filteredNewsIds,
             cursorId = cursorId,

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernewscard/MemberNewsCardRetrieve.kt
@@ -26,11 +26,28 @@ class MemberNewsCardRetrieve(
         val memberCategories = memberCategoryRepository.findByMember(member)
         val filteredNewsIds = filterAlreadySavedNews(member)
 
+        val startDateTime = targetDateTime
+            .withHour(targetDateTime.hour)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+
+        val endDateTime = targetDateTime
+            .withHour(targetDateTime.hour)
+            .withMinute(59)
+            .withSecond(59)
+            .withNano(59)
+
+        println("startDateTime = ${startDateTime}")
+        println("endDateTime = ${endDateTime}")
+
         val newsCards = newsCardRepository.findNewsCardsByMemberFilteredNewsIdsAndCursorId(
             filteredNewsIds = filteredNewsIds,
             cursorId = cursorId,
+            startDateTime = startDateTime,
+            endDateTime = endDateTime,
             categories = memberCategories.map { it.category.id },
-            size = size
+            size = size,
         )
 
         return newsCards.filter { it ->

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
@@ -1,10 +1,14 @@
 package com.mashup.shorts.domain.newscard
 
+import java.time.LocalDateTime
+
 interface NewsCardQueryDSLRepository {
 
     fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
         filteredNewsIds: List<Long>,
         cursorId: Long,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
         categories: List<Long>,
         size: Int,
     ): List<NewsCard>

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
@@ -14,6 +14,8 @@ class NewsCardQueryDSLRepositoryImpl(
     override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
         filteredNewsIds: List<Long>,
         cursorId: Long,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
         categories: List<Long>,
         size: Int,
     ): List<NewsCard> {
@@ -23,8 +25,8 @@ class NewsCardQueryDSLRepositoryImpl(
             .fetchJoin()
             .where(cursorCondition(cursorId))
             .where(categoryCondition(categories))
-            .where(newsCard.createdAt.loe(LocalDateTime.now()))
-            .orderBy(newsCard.id.desc())
+            .where(newsCard.createdAt.between(startDateTime, endDateTime))
+            .orderBy(newsCard.id.asc())
             .limit(size.toLong())
             .fetch()
     }
@@ -55,7 +57,7 @@ class NewsCardQueryDSLRepositoryImpl(
 
     private fun cursorCondition(cursorId: Long): Predicate? {
         return if (cursorId != 0.toLong()) {
-            newsCard.id.lt(cursorId)
+            newsCard.id.gt(cursorId)
         } else {
             null
         }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
@@ -21,10 +21,10 @@ class NewsCardQueryDSLRepositoryImpl(
             .selectFrom(newsCard)
             .join(newsCard.category, category)
             .fetchJoin()
-            .where(newsCard.id.gt(cursorId))
+            .where(cursorCondition(cursorId))
             .where(categoryCondition(categories))
             .where(newsCard.createdAt.loe(LocalDateTime.now()))
-            .orderBy(newsCard.id.asc())
+            .orderBy(newsCard.id.desc())
             .limit(size.toLong())
             .fetch()
     }
@@ -48,6 +48,14 @@ class NewsCardQueryDSLRepositoryImpl(
     private fun categoryCondition(categories: List<Long>): Predicate? {
         return if (categories.isNotEmpty()) {
             newsCard.category.id.`in`(categories)
+        } else {
+            null
+        }
+    }
+
+    private fun cursorCondition(cursorId: Long): Predicate? {
+        return if (cursorId != 0.toLong()) {
+            newsCard.id.lt(cursorId)
         } else {
             null
         }


### PR DESCRIPTION
## 문제점 1

`기존 홈 조회 시 요청 유저의 카테고리를 불러오는 코드`

```kotlin
        val newsCards = newsCardRepository.findNewsCardsByMemberFilteredNewsIdsAndCursorId(
            filteredNewsIds = filteredNewsIds,
            cursorId = cursorId,
            categories = memberCategories.map { it.id },
            size = size
        )
```
위 코드에서 `categories = memberCategories.map { it.id }` 구문이 `category`의 PK가 아닌 `memberCategory`의 PK를 가리키는 것으로 인해 특정 유저의 카테고리를 올바르게 불러올 수 없었습니다.

`따라서 아래와 같이 로직을 수정합니다.`

```kotlin
        val newsCards = newsCardRepository.findNewsCardsByMemberFilteredNewsIdsAndCursorId(
            filteredNewsIds = filteredNewsIds,
            cursorId = cursorId,
            categories = memberCategories.map { it.category.id },
            size = size
        )
```

---

## 문제점 2

`커서 페이징을 하는 과정에서 기존 오름차순 정렬을 수행했던 아래와 같은 쿼리`

```kotlin
    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
        filteredNewsIds: List<Long>,
        cursorId: Long,
        categories: List<Long>,
        size: Int,
    ): List<NewsCard> {
        return queryFactory
            .selectFrom(newsCard)
            .join(newsCard.category, category)
            .fetchJoin()
            .where(newsCard.id.gt(cursorId))
            .where(categoryCondition(categories))
            .where(newsCard.createdAt.loe(LocalDateTime.now()))
            .orderBy(newsCard.id.asc())
            .limit(size.toLong())
            .fetch()
    }
```

로 인해 어느 시점에 조회를 하던 가장 이전의 데이터를 불러오는 현상이 발생했었습니다.

`따라서 다음과 같이 수정합니다.`

```kotlin
    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
        filteredNewsIds: List<Long>,
        cursorId: Long,
        startDateTime: LocalDateTime,
        endDateTime: LocalDateTime,
        categories: List<Long>,
        size: Int,
    ): List<NewsCard> {
        return queryFactory
            .selectFrom(newsCard)
            .join(newsCard.category, category)
            .fetchJoin()
            .where(cursorCondition(cursorId))
            .where(categoryCondition(categories))
            .where(newsCard.createdAt.between(startDateTime, endDateTime))
            .orderBy(newsCard.id.asc())
            .limit(size.toLong())
            .fetch()
    }

    private fun cursorCondition(cursorId: Long): Predicate? {
        return if (cursorId != 0.toLong()) {
            newsCard.id.gt(cursorId)
        } else {
            null
        }
    }
```

커서 기본값은 0으로 지정해두었기 때문에 0이 들어오면 조건절을 넣지 않는 방식으로 오름차순 정렬하여 페이징하도록 변경합니다.

---

## 문제점 3.

기존 코드는 targetDateTime을 Service계층에서 매개변수로 전달 받으나 Repository에서는 조건문으로 사용하지 않고 있었습니다.

따라서 어떤 시간대를 조회하여도 해당 시간대 이전의 데이터만 내려주는 것이 아닌 모든 데이터를 응답하는 방식이었습니다.

`기존 코드`

```kotlin
    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
        filteredNewsIds: List<Long>,
        cursorId: Long,
        categories: List<Long>,
        size: Int,
    ): List<NewsCard> {
        return queryFactory
            .selectFrom(newsCard)
            .join(newsCard.category, category)
            .fetchJoin()
            .where(cursorCondition(cursorId))
            .where(categoryCondition(categories))
            .where(newsCard.createdAt.loe(LocalDateTime.now()))
            .orderBy(newsCard.id.desc())
            .limit(size.toLong())
            .fetch()
    }
```

`변경 후 코드`

```kotlin
    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
        filteredNewsIds: List<Long>,
        cursorId: Long,
        startDateTime: LocalDateTime,
        endDateTime: LocalDateTime,
        categories: List<Long>,
        size: Int,
    ): List<NewsCard> {
        return queryFactory
            .selectFrom(newsCard)
            .join(newsCard.category, category)
            .fetchJoin()
            .where(cursorCondition(cursorId))
            .where(categoryCondition(categories))
            .where(newsCard.createdAt.between(startDateTime, endDateTime))
            .orderBy(newsCard.id.asc())
            .limit(size.toLong())
            .fetch()
    }
```

위와 같이 `starteDateTime`, `endDateTime` 을 조건문에 추가하여 요청한 시간대의 숏스만 불러올 수 있도록 수정했습니다.