### PR TITLE
feat: 핫 키워드 조회

### DIFF
--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/HotKeywordsRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/HotKeywordsRetrieveApi.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.domain.hot.keyword
 
+import java.time.LocalDateTime
 import org.springframework.http.HttpStatus.*
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -8,9 +9,10 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import com.mashup.shorts.common.response.ApiResponse
 import com.mashup.shorts.common.response.ApiResponse.Companion.success
-import com.mashup.shorts.domain.keyword.HotKeywordRetrieve
 import com.mashup.shorts.domain.hot.keyword.dto.HotKeywordsResponse
+import com.mashup.shorts.domain.hot.keyword.dto.KeywordRankingMapper
 import com.mashup.shorts.domain.hot.keyword.dto.RetrieveDetailHotKeywordResponse
+import com.mashup.shorts.domain.keyword.HotKeywordRetrieve
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 
@@ -22,11 +24,8 @@ class HotKeywordsRetrieveApi(
 
     @GetMapping
     fun retrieveHotKeywords(): ApiResponse<HotKeywordsResponse> {
-        val response = HotKeywordsResponse.of(
-            "2023년 6월 17일 17:01 ~ 18:00",
-            listOf("숏스", "또보겠지", "매쉬업", "아오스", "디자인", "스프링", "AI", "짧은 뉴스", "챗 GPT", "해커톤")
-        )
-        return success(OK, response)
+        val keywordRanking = hotKeywordRetrieve.retrieveHotKeywords(LocalDateTime.now())
+        return success(OK, KeywordRankingMapper.keywordRankingToResponse(keywordRanking))
     }
 
     @GetMapping("/{keyword}")

--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/dto/KeywordRankingMapper.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/dto/KeywordRankingMapper.kt
@@ -1,0 +1,13 @@
+package com.mashup.shorts.domain.hot.keyword.dto
+
+import com.mashup.shorts.domain.keyword.KeywordRanking
+
+class KeywordRankingMapper {
+
+    companion object {
+
+        fun keywordRankingToResponse(keywordRanking: KeywordRanking): HotKeywordsResponse {
+            return HotKeywordsResponse(keywordRanking.createdAt, keywordRanking.ranking)
+        }
+    }
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeyword.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeyword.kt
@@ -1,0 +1,15 @@
+package com.mashup.shorts.domain.keyword
+
+import com.mashup.shorts.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+
+@Table(name = "hot_keyword")
+@Entity
+class HotKeyword(
+
+    @Column(name = "keyword_ranking", nullable = false, length = 200)
+    var keywordRanking: String
+
+) : BaseEntity()

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRepository.kt
@@ -1,0 +1,7 @@
+package com.mashup.shorts.domain.keyword
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface HotKeywordRepository : JpaRepository<HotKeyword, Long>

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRepository.kt
@@ -1,7 +1,11 @@
 package com.mashup.shorts.domain.keyword
 
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface HotKeywordRepository : JpaRepository<HotKeyword, Long>
+interface HotKeywordRepository : JpaRepository<HotKeyword, Long> {
+
+    fun findByCreatedAtAfter(createdAt: LocalDateTime): HotKeyword?
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/KeywordRanking.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/KeywordRanking.kt
@@ -1,0 +1,6 @@
+package com.mashup.shorts.domain.keyword
+
+data class KeywordRanking(
+    val createdAt: String,
+    val ranking: List<String>
+)

--- a/shorts-domain/src/main/resources/db/migration/V2__add_hot_keyword.sql
+++ b/shorts-domain/src/main/resources/db/migration/V2__add_hot_keyword.sql
@@ -1,0 +1,7 @@
+create table hot_keyword
+(
+    id            bigint auto_increment primary key,
+    keyword_ranking      varchar(200) not null,
+    created_at    datetime(6)  not null,
+    modified_at   datetime(6)  null
+);


### PR DESCRIPTION
### 전달사항
- 동일 랭킹 고려하지 않고 우선은 키워드 10개 저장으로만 구현했습니다.

### 참고
크롤링한 뉴스들의 키워드 개수를 계산하다보니 동일한 랭킹의 키워드가 있을 수 있는데, 이때 핫 키워드 반환을 어떻게 해야하는지?

1) 동일 랭킹 포함하여 랭킹 10위까지의 키워드 모두 보내기
-> 핫 키워드 개수가 10개 초과될 수 있음

2) 동일 랭킹 상관없이 무조건 키워드 10개만 보내기
-> 10위까지의 키워드가 모두 포함되지 않을 수 있음