### PR TITLE
크롤러 중 버그를 해결합니다.

### DIFF
--- a/shorts-crawler/src/main/resources/application-dev.yml
+++ b/shorts-crawler/src/main/resources/application-dev.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: dev

--- a/shorts-crawler/src/main/resources/application-local.yml
+++ b/shorts-crawler/src/main/resources/application-local.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: local

--- a/shorts-crawler/src/main/resources/application-prod.yml
+++ b/shorts-crawler/src/main/resources/application-prod.yml
@@ -1,0 +1,4 @@
+spring:
+  config:
+    activate:
+      on-profile: prod

--- a/shorts-crawler/src/main/resources/application.yml
+++ b/shorts-crawler/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  application:
+    name: shorts-web
+  messages:
+    encoding: UTF-8

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
@@ -1,7 +1,6 @@
 package com.mashup.shorts.domain.news
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.category.Category
 
@@ -10,6 +9,5 @@ interface NewsRepository : JpaRepository<News, Long>, NewsQueryDSLRepository {
 
     fun findAllByCategory(category: Category): List<News>
 
-    @Query("SELECT distinct * FROM news WHERE news.title = :title", nativeQuery = true)
-    fun customFindByTitle(title: String): News?
+    fun findByTitleAndPress(title: String, press: String): News?
 }


### PR DESCRIPTION
## 버그 내용

크롤링 시점에서 뉴스 저장 시 크롤링된 카운트를 증가시키기 위한 로직을 처리하기 위해, 같은 제목을 가진 뉴스를 DB에서 불러오는 중

언론사는 다르나 기사 제목이 똑같은 경우 findBy의 리턴 값이 2개 이상으로 결과가 반환되어 런타임 에러가 발생하던 버그를 수정합니다.

## 해결방안

```kotlin
    fun findByTitleAndPress(title: String, press: String): News?
```

위 조회 메서드로 언론사와 기사제목을 함께 조건절을 넣어 조회하는 것으로 같은 기사제목이지만 언론사가 다른 뉴스 조회가 2건 이상 발생하지 않도록 수정합니다.