### PR TITLE
오래 간직할 뉴스 조회 시 대상 월/일을 동적으로 조회할 수 있도록 수정

### DIFF
--- a/shorts-api/src/docs/asciidoc/home/index.adoc
+++ b/shorts-api/src/docs/asciidoc/home/index.adoc
@@ -15,7 +15,6 @@ image::https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/45676906/82651c72
 
 include::../../../../../shorts-api/{snippets}/멤버 관심 카테고리 설정/page-header.adoc[]
 
-
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/멤버 관심 카테고리 설정/http-request.adoc[]
@@ -72,6 +71,10 @@ include::../../../../../shorts-api/{snippets}/숏스 모두 불러오기/page-he
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/숏스 모두 불러오기/http-request.adoc[]
+
+==== [Query Parameters]
+
+include::../../../../../shorts-api/{snippets}/숏스 모두 불러오기/query-parameters.adoc[]
 
 ==== [Request Header]
 

--- a/shorts-api/src/docs/asciidoc/hot/index.adoc
+++ b/shorts-api/src/docs/asciidoc/hot/index.adoc
@@ -39,6 +39,14 @@ include::../../../../../shorts-api/{snippets}/핫 키워드로 숏스 조회/pag
 
 include::../../../../../shorts-api/{snippets}/핫 키워드로 숏스 조회/http-request.adoc[]
 
+==== [Path Parameters]
+
+include::../../../../../shorts-api/{snippets}/핫 키워드로 숏스 조회/path-parameters.adoc[]
+
+==== [Query Parameters]
+
+include::../../../../../shorts-api/{snippets}/핫 키워드로 숏스 조회/query-parameters.adoc[]
+
 ==== [Response Field]
 
 include::../../../../../shorts-api/{snippets}/핫 키워드로 숏스 조회/response-fields.adoc[]

--- a/shorts-api/src/docs/asciidoc/my/index.adoc
+++ b/shorts-api/src/docs/asciidoc/my/index.adoc
@@ -65,13 +65,17 @@ image::https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/60564431/f6e5892f
 
 include::../../../../../shorts-api/{snippets}/저장한 오늘의 숏스 조회/page-header.adoc[]
 
+==== [Request Header]
+
+include::../../../../../shorts-api/{snippets}/저장한 오늘의 숏스 조회/request-headers.adoc[]
+
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/저장한 오늘의 숏스 조회/http-request.adoc[]
 
-==== [Request Header]
+==== [Query Parameters]
 
-include::../../../../../shorts-api/{snippets}/저장한 오늘의 숏스 조회/request-headers.adoc[]
+include::../../../../../shorts-api/{snippets}/저장한 오늘의 숏스 조회/query-parameters.adoc[]
 
 ==== [Request Filed]
 
@@ -113,13 +117,17 @@ image::https://github.com/wjdrbs96/Today-I-Learn/assets/45676906/f60c1765-a30d-4
 
 include::../../../../../shorts-api/{snippets}/오늘의 숏스 삭제/page-header.adoc[]
 
+==== [Request Header]
+
+include::../../../../../shorts-api/{snippets}/오늘의 숏스 삭제/request-headers.adoc[]
+
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/오늘의 숏스 삭제/http-request.adoc[]
 
-==== [Request Header]
+==== [Request Fields]
 
-include::../../../../../shorts-api/{snippets}/오늘의 숏스 삭제/request-headers.adoc[]
+include::../../../../../shorts-api/{snippets}/오늘의 숏스 삭제/request-fields.adoc[]
 
 ==== [Response Field]
 
@@ -171,13 +179,17 @@ image::https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/60564431/dfef33e8
 
 include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조회/page-header.adoc[]
 
+==== [Request Header]
+
+include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조회/request-headers.adoc[]
+
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조회/http-request.adoc[]
 
-==== [Request Header]
+==== [Query Parameters]
 
-include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조회/request-headers.adoc[]
+include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조회/query-parameters.adoc[]
 
 ==== [Response Field]
 
@@ -189,20 +201,23 @@ include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 모두 조
 
 ---
 
-
 === 오래 간직할 숏스 삭제
 
 ==== [Request URI]
 
 include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 삭제/page-header.adoc[]
 
+==== [Request Header]
+
+include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 삭제/request-headers.adoc[]
+
 ==== [HTTP Request]
 
 include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 삭제/http-request.adoc[]
 
-==== [Request Header]
+==== [Request Field]
 
-include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 삭제/request-headers.adoc[]
+include::../../../../../shorts-api/{snippets}/오래 간직할 뉴스 삭제/request-fields.adoc[]
 
 ==== [Response Field]
 
@@ -222,10 +237,6 @@ image::https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/45676906/368fa0a2
 
 include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/page-header.adoc[]
 
-==== [HTTP Request]
-
-include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/http-request.adoc[]
-
 ==== [Request Header]
 
 include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/request-headers.adoc[]
@@ -233,6 +244,10 @@ include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/request-heade
 ==== [Request Path Parameter]
 
 include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/path-parameters.adoc[]
+
+==== [HTTP Request]
+
+include::../../../../../shorts-api/{snippets}/뉴스 상세 조회/http-request.adoc[]
 
 ==== [Response Field]
 

--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/MemberNewsRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/MemberNewsRetrieveApi.kt
@@ -28,6 +28,7 @@ class MemberNewsRetrieveApi(
     @Auth
     @GetMapping
     fun retrieveNewsByMember(
+        @RequestParam targetDate: LocalDate,
         @RequestParam cursorWrittenDateTime: String,
         @RequestParam(required = true) @Min(1) @Max(20) size: Int,
         @RequestParam pivot: Pivots,
@@ -40,6 +41,7 @@ class MemberNewsRetrieveApi(
                 savedNewsCount = memberNewsRetrieve.retrieveMemberNewsCount(member),
                 memberNewsResponse = persistenceToResponseForm(
                     memberNewsRetrieve.retrieveMemberNews(
+                        targetDate = targetDate,
                         member = member,
                         cursorWrittenDateTime = cursorWrittenDateTime,
                         size = size,

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.api.restdocs.member.news
 
+import java.time.LocalDate
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
@@ -30,13 +31,14 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
 
     @Test
     fun `오래 간직할 뉴스 모두 조회`() {
+        val targetDate = LocalDate.of(2023, 6, 30)
         val cursorWrittenDateTime = "2023.06.15. 오후 3:38"
         val size = 10
         val pivot = "ASC"
         val uniqueKey = "uniqueKey"
         val headerName = "Authorization"
 
-        every { memberNewsRetrieve.retrieveMemberNews(any(), any(), any(), any()) } returns (
+        every { memberNewsRetrieve.retrieveMemberNews(any(), any(), any(), any(), any()) } returns (
             listOf(
                 News(
                     title = "뉴스 제목",
@@ -55,6 +57,7 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
             RestDocumentationRequestBuilders
                 .get("/v1/member-news")
                 .header(headerName, uniqueKey)
+                .param("targetDate", targetDate.toString())
                 .param("cursorWrittenDateTime", cursorWrittenDateTime)
                 .param("size", size.toString())
                 .param("pivot", pivot)
@@ -72,6 +75,9 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
                         HeaderDocumentation.headerWithName("Authorization").description("사용자 식별자 id")
                     ),
                     RequestDocumentation.queryParameters(
+                        RequestDocumentation
+                            .parameterWithName("targetDate")
+                            .description("LocalDate 타입, 조회할 날짜를 입력해주세요"),
                         RequestDocumentation
                             .parameterWithName("cursorWrittenDateTime")
                             .description("STRING 타입, 커서 지정 값 ex) 2023.06.15. 오후 3:38 와 같이 입력해 주시고, 첫 페이지 요청 시 빈 문자열을 넣어주세요"),

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRetrieve.kt
@@ -1,5 +1,8 @@
 package com.mashup.shorts.domain.membernews
 
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import com.mashup.shorts.domain.member.Member
@@ -15,13 +18,26 @@ class MemberNewsRetrieve(
 ) {
 
     fun retrieveMemberNews(
+        targetDate: LocalDate,
         member: Member,
         cursorWrittenDateTime: String,
         size: Int,
         pivot: Pivots,
     ): List<News> {
         val memberNewsBundle = memberNewsRepository.findAllByMember(member)
-        return newsRepository.loadNewsBundleByCursorAndNewsCardMultipleNews(
+
+        val firstDayOfMonth = LocalDateTime.of(
+            targetDate.withDayOfMonth(1),
+            LocalTime.of(0, 0)
+        )
+        val lastDayOfMonth = LocalDateTime.of(
+            targetDate.withDayOfMonth(targetDate.lengthOfMonth()),
+            LocalTime.of(23, 59)
+        )
+
+        return newsRepository.loadNewsBundleByCursorAndNewsCardMultipleNewsAndTargetTime(
+            firstDayOfMonth,
+            lastDayOfMonth,
             cursorWrittenDateTime,
             memberNewsBundle.map { it.news.id },
             size,

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
@@ -1,8 +1,18 @@
 package com.mashup.shorts.domain.news
 
+import java.time.LocalDateTime
 import com.mashup.shorts.domain.newscard.Pivots
 
 interface NewsQueryDSLRepository {
+
+    fun loadNewsBundleByCursorAndNewsCardMultipleNewsAndTargetTime(
+        firstDayOfMonth: LocalDateTime,
+        lastDayOfMonth: LocalDateTime,
+        cursorWrittenDateTime: String,
+        newsCardMultipleNews: List<Long>,
+        size: Int,
+        pivot: Pivots,
+    ): List<News>
 
     fun loadNewsBundleByCursorAndNewsCardMultipleNews(
         cursorWrittenDateTime: String,
@@ -10,4 +20,6 @@ interface NewsQueryDSLRepository {
         size: Int,
         pivot: Pivots,
     ): List<News>
+
+
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.domain.news
 
+import java.time.LocalDateTime
 import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.news.QNews.news
 import com.mashup.shorts.domain.newscard.Pivots
@@ -11,6 +12,30 @@ import com.querydsl.jpa.impl.JPAQueryFactory
 class NewsQueryDSLRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : NewsQueryDSLRepository {
+
+    override fun loadNewsBundleByCursorAndNewsCardMultipleNewsAndTargetTime(
+        firstDayOfMonth: LocalDateTime,
+        lastDayOfMonth: LocalDateTime,
+        cursorWrittenDateTime: String,
+        newsCardMultipleNews: List<Long>,
+        size: Int,
+        pivot: Pivots,
+    ): List<News> {
+        return queryFactory
+            .selectFrom(news)
+            .where(
+                cursorWrittenDateTimeLessThanGraterThanSpecifyByPivot(
+                    cursorWrittenDateTime,
+                    pivot,
+                    newsCardMultipleNews
+                )
+            ).where(
+                news.createdAt.between(firstDayOfMonth, lastDayOfMonth)
+            )
+            .orderBy(writtenDateTimeOrderSpecifyByPivot(pivot))
+            .limit(size.toLong())
+            .fetch()
+    }
 
     override fun loadNewsBundleByCursorAndNewsCardMultipleNews(
         cursorWrittenDateTime: String,

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardRetrieve.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.domain.newscard
 
+import java.time.LocalDate
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional


### PR DESCRIPTION
### 추가사항 1.

오래 간직할 뉴스 조회 시 대상 월/일을 동적으로 조회할 수 있도록 수정합니다.

### 추가사항 2.

Rest DOCS에 Path Parameter, Query Parameter, Request Field를 추가합니다.