### PR TITLE
크롤링 데이터 벌크 삽입으로 개선

### DIFF
--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsBulkInsertRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsBulkInsertRepository.kt
@@ -1,0 +1,49 @@
+package com.mashup.shorts.domain.news
+
+import java.sql.PreparedStatement
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
+
+
+@Repository
+class NewsBulkInsertRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
+
+    @Transactional
+    fun bulkInsert(newsBundle: List<News>, crawledDateTime: LocalDateTime): Long? {
+        val sql =
+            """INSERT INTO news (title, content, news_link, press, thumbnail_image_url, type, written_date_time, crawled_count, category_id, created_at, modified_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """.trimMargin()
+
+        jdbcTemplate.batchUpdate(
+            sql,
+            object : BatchPreparedStatementSetter {
+                override fun setValues(ps: PreparedStatement, i: Int) {
+                    val news = newsBundle[i]
+                    ps.setString(1, news.title)
+                    ps.setString(2, news.content)
+                    ps.setString(3, news.newsLink)
+                    ps.setString(4, news.press)
+                    ps.setString(5, news.thumbnailImageUrl)
+                    ps.setString(6, news.type)
+                    ps.setString(7, news.writtenDateTime)
+                    ps.setInt(8, news.crawledCount)
+                    ps.setLong(9, news.category.id)
+                    ps.setTimestamp(10, Timestamp.valueOf(crawledDateTime))
+                    ps.setTimestamp(11, Timestamp.valueOf(LocalDateTime.now()))
+                }
+
+                override fun getBatchSize(): Int {
+                    return newsBundle.size
+                }
+            }
+        )
+        return jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long::class.java)
+    }
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
@@ -9,4 +9,5 @@ interface NewsRepository : JpaRepository<News, Long>, NewsQueryDSLRepository {
 
     fun findAllByCategory(category: Category): List<News>
     fun findByTitleAndNewsLinkAndPress(title: String, newsLink: String, press: String): List<News>
+    fun findTopByOrderByIdDesc(): News?
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardBulkInsertRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardBulkInsertRepository.kt
@@ -1,12 +1,41 @@
 package com.mashup.shorts.domain.newscard
 
+import java.sql.PreparedStatement
+import java.sql.Timestamp
+import java.time.LocalDateTime
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 
 @Repository
 class NewsCardBulkInsertRepository(
     private val jdbcTemplate: JdbcTemplate,
 ) {
 
+    @Transactional
+    fun bulkInsert(newsCards: List<NewsCard>, crawledDateTime: LocalDateTime) {
+        val sql =
+            """INSERT INTO news_card (multiple_news, keywords, category_id, created_at, modified_at)
+                VALUES (?, ?, ?, ?, ?)
+            """.trimMargin()
 
+        jdbcTemplate.batchUpdate(
+            sql,
+            object : BatchPreparedStatementSetter {
+                override fun setValues(ps: PreparedStatement, i: Int) {
+                    val newsCard = newsCards[i]
+                    ps.setString(1, newsCard.multipleNews)
+                    ps.setString(2, newsCard.keywords)
+                    ps.setLong(3, newsCard.category.id)
+                    ps.setTimestamp(4, Timestamp.valueOf(newsCard.createdAt))
+                    ps.setTimestamp(5, Timestamp.valueOf(newsCard.modifiedAt))
+                }
+
+                override fun getBatchSize(): Int {
+                    return newsCards.size
+                }
+            }
+        )
+    }
 }


### PR DESCRIPTION
## 문제점

크롤링 중 간헐적으로 `too many connections`이라는 MySQL 에러가 발생하였고 이 원인 또한 과한 커넥션 사용으로 인한 커넥션이 부족해진다는 것이 원인이었습니다.

이 문제점을 개선하고자 `Slow Query`가 발생하는 부분을 발견하였고 그 원인은 각 `Entity를 하나씩 INSERT` 하는 쿼리를 보낸다는 것이었습니다.

## 해결방안

크롤링하여 가공한 데이터는 `벌크 연산`으로 삽입하도록 개선하여 DB접근 시 커넥션을 사용하는 주기 및 횟수를 최소화 하고 매번Connection을 맺고 끊는 과정에서 발생하는 `오버헤드를 감소`시켰습니다.

벌크 연산은 JdbcTemplate을 사용했습니다.

> JdbcTemplate을 사용한 이유는 아래 블로그에 해결 과정을 정리했습니다. 참고 부탁드립니다.
>
> [JPA vs JdbcTemplate vs MyBatis](https://k-diger.github.io/posts/BulkInsertWithSpring/)

## 적용 후

![image](https://github.com/mash-up-kr/SeeYouAgain_Spring/assets/60564431/927df804-a0c1-43c1-a7bf-7ebfcefb7552)

기존 크롤링 중 60개 이상 사용하던 Connection Thread가 23개 이하로 감소되었습니다.