### PR TITLE
뉴스 카드 내 뉴스 조회, 오래 간직할 뉴스 조회 시 writtenDateTime으로 정렬되지 않던 버그 수정

### DIFF
--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/MemberNewsRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/MemberNewsRetrieveApi.kt
@@ -41,8 +41,10 @@ class MemberNewsRetrieveApi(
         return success(
             OK,
             MemberNewsRetrieveResponse(
-                today = LocalDate.now(),
-                savedNewsCount = memberNewsRetrieve.retrieveMemberNewsCount(member),
+                savedNewsCount = memberNewsRetrieve.retrieveMemberNewsCountByTargetDateTime(
+                    member,
+                    targetDate
+                ),
                 memberNewsResponse = persistenceToResponseForm(
                     memberNewsRetrieve.retrieveMemberNews(
                         targetDate = targetDate,

--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/dto/MemberNewsResponse.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernews/dto/MemberNewsResponse.kt
@@ -1,10 +1,8 @@
 package com.mashup.shorts.domain.my.membernews.dto
 
-import java.time.LocalDate
 import com.mashup.shorts.domain.news.News
 
 data class MemberNewsRetrieveResponse(
-    val today: LocalDate = LocalDate.now(),
     var savedNewsCount: Int = 0,
     var memberNewsResponse: List<MemberNewsResponse>,
 )

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/integrate/domain/newscard/NewsCardIntegrateTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/integrate/domain/newscard/NewsCardIntegrateTest.kt
@@ -22,7 +22,7 @@ import com.mashup.shorts.domain.member.Member
 
 @SpringBootTest
 @Disabled
-@ActiveProfiles("test")
+//@ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
@@ -52,7 +52,7 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
                     category = Category(CategoryName.SCIENCE)
                 )
             ))
-        every { memberNewsRetrieve.retrieveMemberNewsCount(any()) } returns (1234)
+        every { memberNewsRetrieve.retrieveMemberNewsCountByTargetDateTime(any(), any()) } returns (1234)
         val response = mockMvc.perform(
             RestDocumentationRequestBuilders
                 .get("/v1/member-news")
@@ -91,10 +91,8 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
                     responseFields(
                         PayloadDocumentation.fieldWithPath("status").type(JsonFieldType.NUMBER)
                             .description("API 성공 여부"),
-                        PayloadDocumentation.fieldWithPath("result.today").type(JsonFieldType.STRING)
-                            .description("오늘 날짜"),
                         PayloadDocumentation.fieldWithPath("result.savedNewsCount").type(JsonFieldType.NUMBER)
-                            .description("저장한 뉴스 갯수"),
+                            .description("요청한 월에 저장한 뉴스 갯수"),
                         PayloadDocumentation.subsectionWithPath("result.memberNewsResponse[]")
                             .description("멤버 뉴스 응답"),
                         PayloadDocumentation.fieldWithPath("result.memberNewsResponse[].id")

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/news/MemberNewsRetrieveApiTest.kt
@@ -80,7 +80,7 @@ class MemberNewsRetrieveApiTest : ApiDocsTestBase() {
                             .description("LocalDate 타입, 조회할 날짜를 입력해주세요"),
                         RequestDocumentation
                             .parameterWithName("cursorWrittenDateTime")
-                            .description("STRING 타입, 커서 지정 값 ex) 2023.06.15. 오후 3:38 와 같이 입력해 주시고, 첫 페이지 요청 시 빈 문자열을 넣어주세요"),
+                            .description("커서 지정 값 ex) 2023.06.15. 오후 3:38 와 같이 입력해 주시고, 첫 페이지 요청 시 빈 값으로 요청해주세요 (빈 문자열 X)"),
                         RequestDocumentation
                             .parameterWithName("size")
                             .description("<필수값> 페이징 사이즈(최대 20까지 허용합니다.)"),

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/newcard/NewsCardRetrieveApiRestDocsTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/newcard/NewsCardRetrieveApiRestDocsTest.kt
@@ -72,7 +72,7 @@ class NewsCardRetrieveApiRestDocsTest : ApiDocsTestBase() {
                     RequestDocumentation.queryParameters(
                         RequestDocumentation
                             .parameterWithName("cursorWrittenDateTime")
-                            .description("커서 지정 값 ex) 2023.06.15. 오후 3:38 와 같이 입력해 주시고, 첫 페이지 요청 시 빈 문자열을 넣어주세요"),
+                            .description("커서 지정 값 ex) 2023.06.15. 오후 3:38 와 같이 입력해 주시고, 첫 페이지 요청 시 빈 값으로 요청해주세요 (빈 문자열 X)"),
                         RequestDocumentation
                             .parameterWithName("size")
                             .description("<필수값> 페이징 사이즈(최대 20까지 허용합니다.)"),

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRetrieve.kt
@@ -43,14 +43,13 @@ class HotKeywordRetrieve(
             LocalTime.of(23, 59)
         )
 
-        return newsRepository.loadNewsBundleByCursorIdAndNewsCardMultipleNewsAndTargetTime(
+        return newsRepository.loadNewsBundleByCursorIdAndTargetTime(
             firstDayOfMonth,
             lastDayOfMonth,
             cursorId,
             newsIds.flatten(),
             size,
         )
-
     }
 
     fun retrieveHotKeywords(targetTime: LocalDateTime): KeywordRanking {

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRepository.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.domain.membernews
 
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.member.Member
@@ -16,4 +17,10 @@ interface MemberNewsRepository : JpaRepository<MemberNews, Long> {
     fun countAllByMember(member: Member): Int
 
     fun findAllByMember(member: Member): List<MemberNews>
+
+    fun countByMemberAndCreatedAtBetween(
+        member: Member,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
+    ): Int
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/membernews/MemberNewsRetrieve.kt
@@ -24,14 +24,9 @@ class MemberNewsRetrieve(
         size: Int,
         pivot: Pivots,
     ): List<News> {
-        val firstDayOfMonth = LocalDateTime.of(
-            targetDate.withDayOfMonth(1),
-            LocalTime.of(0, 0)
-        )
-        val lastDayOfMonth = LocalDateTime.of(
-            targetDate.withDayOfMonth(targetDate.lengthOfMonth()),
-            LocalTime.of(23, 59)
-        )
+        val targetDateTimePeriod = parseTargetDateTimePeriod(targetDate)
+        val firstDayOfMonth = targetDateTimePeriod.first
+        val lastDayOfMonth = targetDateTimePeriod.second
 
         if (cursorWrittenDateTime.isEmpty()) {
             return notContainedCursor(
@@ -54,8 +49,19 @@ class MemberNewsRetrieve(
 
     }
 
-    fun retrieveMemberNewsCount(member: Member): Int {
-        return memberNewsRepository.findAllByMember(member).size
+    fun retrieveMemberNewsCountByTargetDateTime(
+        member: Member,
+        targetDate: LocalDate,
+    ): Int {
+        val targetDateTimePeriod = parseTargetDateTimePeriod(targetDate)
+        val firstDayOfMonth = targetDateTimePeriod.first
+        val lastDayOfMonth = targetDateTimePeriod.second
+
+        return memberNewsRepository.countByMemberAndCreatedAtBetween(
+            member,
+            firstDayOfMonth,
+            lastDayOfMonth
+        )
     }
 
     private fun notContainedCursor(
@@ -127,5 +133,18 @@ class MemberNewsRetrieve(
             newsBundle.map { it.id },
             size
         ).sortedByDescending { it.writtenDateTime }
+    }
+
+    private fun parseTargetDateTimePeriod(targetDate: LocalDate): Pair<LocalDateTime, LocalDateTime> {
+        val firstDayOfMonth = LocalDateTime.of(
+            targetDate.withDayOfMonth(1),
+            LocalTime.of(0, 0)
+        )
+        val lastDayOfMonth = LocalDateTime.of(
+            targetDate.withDayOfMonth(targetDate.lengthOfMonth()),
+            LocalTime.of(23, 59)
+        )
+
+        return Pair(firstDayOfMonth, lastDayOfMonth)
     }
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
@@ -1,20 +1,17 @@
 package com.mashup.shorts.domain.news
 
 import java.time.LocalDateTime
-import com.mashup.shorts.domain.newscard.Pivots
 
 interface NewsQueryDSLRepository {
 
     fun loadNewsBundleByCursorAndNewsCardMultipleNewsAndTargetTime(
         firstDayOfMonth: LocalDateTime,
         lastDayOfMonth: LocalDateTime,
-        cursorWrittenDateTime: String,
         newsIds: List<Long>,
         size: Int,
-        pivot: Pivots,
     ): List<News>
 
-    fun loadNewsBundleByCursorIdAndNewsCardMultipleNewsAndTargetTime(
+    fun loadNewsBundleByCursorIdAndTargetTime(
         firstDayOfMonth: LocalDateTime,
         lastDayOfMonth: LocalDateTime,
         cursorId: Long,
@@ -23,9 +20,7 @@ interface NewsQueryDSLRepository {
     ): List<News>
 
     fun loadNewsBundleByCursorAndNewsCardMultipleNews(
-        cursorWrittenDateTime: String,
         newsIds: List<Long>,
         size: Int,
-        pivot: Pivots,
     ): List<News>
 }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
@@ -3,9 +3,6 @@ package com.mashup.shorts.domain.news
 import java.time.LocalDateTime
 import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.news.QNews.news
-import com.mashup.shorts.domain.newscard.Pivots
-import com.querydsl.core.types.OrderSpecifier
-import com.querydsl.core.types.dsl.BooleanExpression
 import com.querydsl.jpa.impl.JPAQueryFactory
 
 @Repository
@@ -16,28 +13,18 @@ class NewsQueryDSLRepositoryImpl(
     override fun loadNewsBundleByCursorAndNewsCardMultipleNewsAndTargetTime(
         firstDayOfMonth: LocalDateTime,
         lastDayOfMonth: LocalDateTime,
-        cursorWrittenDateTime: String,
         newsIds: List<Long>,
         size: Int,
-        pivot: Pivots,
     ): List<News> {
         return queryFactory
             .selectFrom(news)
-            .where(
-                cursorWrittenDateTimeLessThanGraterThanSpecifyByPivot(
-                    cursorWrittenDateTime,
-                    pivot,
-                    newsIds
-                )
-            ).where(
-                news.createdAt.between(firstDayOfMonth, lastDayOfMonth)
-            )
-            .orderBy(writtenDateTimeOrderSpecifyByPivot(pivot))
+            .where(news.id.`in`(newsIds))
+            .where(news.createdAt.between(firstDayOfMonth, lastDayOfMonth))
             .limit(size.toLong())
             .fetch()
     }
 
-    override fun loadNewsBundleByCursorIdAndNewsCardMultipleNewsAndTargetTime(
+    override fun loadNewsBundleByCursorIdAndTargetTime(
         firstDayOfMonth: LocalDateTime,
         lastDayOfMonth: LocalDateTime,
         cursorId: Long,
@@ -46,51 +33,21 @@ class NewsQueryDSLRepositoryImpl(
     ): List<News> {
         return queryFactory
             .selectFrom(news)
+            .where(news.id.`in`(newsIds))
             .where(news.id.gt(cursorId))
             .where(news.createdAt.between(firstDayOfMonth, lastDayOfMonth))
-            .orderBy(news.id.asc())
             .limit(size.toLong())
             .fetch()
     }
 
     override fun loadNewsBundleByCursorAndNewsCardMultipleNews(
-        cursorWrittenDateTime: String,
-        newsCardMultipleNews: List<Long>,
+        newsIds: List<Long>,
         size: Int,
-        pivot: Pivots,
     ): List<News> {
         return queryFactory
             .selectFrom(news)
-            .where(
-                cursorWrittenDateTimeLessThanGraterThanSpecifyByPivot(
-                    cursorWrittenDateTime,
-                    pivot,
-                    newsCardMultipleNews
-                )
-            )
-            .orderBy(writtenDateTimeOrderSpecifyByPivot(pivot))
+            .where(news.id.`in`(newsIds))
             .limit(size.toLong())
             .fetch()
-    }
-
-    private fun cursorWrittenDateTimeLessThanGraterThanSpecifyByPivot(
-        cursorWrittenDateTime: String,
-        pivot: Pivots,
-        newsIds: List<Long>,
-    ): BooleanExpression? {
-        if (cursorWrittenDateTime == "") {
-            return news.id.`in`(newsIds)
-        }
-
-        return if (pivot == Pivots.ASC) {
-            news.writtenDateTime.gt(cursorWrittenDateTime)
-                .and(news.id.`in`(newsIds))
-        } else
-            news.writtenDateTime.lt(cursorWrittenDateTime)
-                .and(news.id.`in`(newsIds))
-    }
-
-    private fun writtenDateTimeOrderSpecifyByPivot(pivot: Pivots): OrderSpecifier<String> {
-        return if (pivot == Pivots.ASC) news.writtenDateTime.asc() else news.writtenDateTime.desc()
     }
 }


### PR DESCRIPTION
 뉴스 카드 내 뉴스 조회, 오래 간직할 뉴스 조회 시 writtenDateTime으로 커서 페이징 정렬되지 않던 버그 수정

## 기존 문제점

기존 QueryDSL을 사용하면서 String타입의 

Qnews.news.writtenDateTime으로 최신순/오래된순을 정렬하던 로직이 올바르게 정렬되지 않던 버그를 발견했습니다.

## 해결방법

해결하기 위해 Query단위로 해결하지 않고 비즈니스 로직 내에서 필터링을 통해 해결하도록 변경하였습니다.