### PR TITLE
핫 키워드 조회 버그 수정

### DIFF
--- a/shorts-api/src/docs/asciidoc/hot/index.adoc
+++ b/shorts-api/src/docs/asciidoc/hot/index.adoc
@@ -39,10 +39,6 @@ include::../../../../../shorts-api/{snippets}/핫 키워드로 뉴스 조회/pag
 
 include::../../../../../shorts-api/{snippets}/핫 키워드로 뉴스 조회/http-request.adoc[]
 
-==== [Path Parameters]
-
-include::../../../../../shorts-api/{snippets}/핫 키워드로 뉴스 조회/path-parameters.adoc[]
-
 ==== [Query Parameters]
 
 include::../../../../../shorts-api/{snippets}/핫 키워드로 뉴스 조회/query-parameters.adoc[]

--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/home/news/NewsRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/home/news/NewsRetrieveApi.kt
@@ -1,16 +1,21 @@
 package com.mashup.shorts.domain.home.news
 
+import java.time.LocalDateTime
 import org.springframework.http.HttpStatus.OK
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import com.mashup.shorts.common.aop.Auth
 import com.mashup.shorts.common.aop.AuthContext
 import com.mashup.shorts.common.response.ApiResponse
 import com.mashup.shorts.domain.home.news.dto.NewsRetrieveMapper
 import com.mashup.shorts.domain.home.news.dto.NewsRetrieveResponse
+import com.mashup.shorts.domain.home.newscard.dto.RetrieveNewsBundleInNewsCardResponse
 import com.mashup.shorts.domain.news.NewsRetrieve
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
 
 @RestController
 @RequestMapping("/v1/news")
@@ -30,6 +35,32 @@ class NewsRetrieveApi(
         return ApiResponse.success(
             OK,
             NewsRetrieveMapper.newsRetrieveInfoToResponse(newsRetrieveInfo)
+        )
+    }
+
+    /**
+    키워드로 관련 뉴스 조회 API
+    @PathVariable : keyword
+    @Param : targetDateTime, cursorId, size
+     */
+    @GetMapping
+    fun retrieveDetailHotKeyword(
+        @RequestParam keyword: String,
+        @RequestParam targetDateTime: LocalDateTime,
+        @RequestParam(defaultValue = "0", required = false) @Min(0) @Max(Long.MAX_VALUE)
+        cursorId: Long,
+        @RequestParam(required = true) @Min(1) @Max(20) size: Int,
+    ): ApiResponse<List<RetrieveNewsBundleInNewsCardResponse>> {
+        return ApiResponse.success(
+            OK,
+            RetrieveNewsBundleInNewsCardResponse.persistenceToResponseForm(
+                newsRetrieve.retrieveByHotKeyword(
+                    targetDateTime = targetDateTime,
+                    keyword = keyword,
+                    cursorId = cursorId,
+                    size = size
+                )
+            )
         )
     }
 }

--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/HotKeywordsRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/hot/keyword/HotKeywordsRetrieveApi.kt
@@ -33,30 +33,4 @@ class HotKeywordsRetrieveApi(
         val keywordRanking = hotKeywordRetrieve.retrieveHotKeywords(targetTime)
         return success(OK, KeywordRankingMapper.keywordRankingToResponse(keywordRanking))
     }
-
-    /**
-    키워드로 관련 뉴스 조회 API
-    @PathVariable : keyword
-    @Param : targetDateTime, cursorId, size
-     */
-    @GetMapping("/{keyword}")
-    fun retrieveDetailHotKeyword(
-        @PathVariable keyword: String,
-        @RequestParam targetDateTime: LocalDateTime,
-        @RequestParam(defaultValue = "0", required = false) @Min(0) @Max(Long.MAX_VALUE)
-        cursorId: Long,
-        @RequestParam(required = true) @Min(1) @Max(20) size: Int,
-    ): ApiResponse<List<RetrieveNewsBundleInNewsCardResponse>> {
-        return success(
-            OK,
-            RetrieveNewsBundleInNewsCardResponse.persistenceToResponseForm(
-                hotKeywordRetrieve.retrieveDetailHotKeyword(
-                    targetDateTime = targetDateTime,
-                    keyword = keyword,
-                    cursorId = cursorId,
-                    size = size
-                )
-            )
-        )
-    }
 }

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/keyword/HotKeywordsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/keyword/HotKeywordsRetrieveApiTest.kt
@@ -1,29 +1,21 @@
 package com.mashup.shorts.api.restdocs.keyword
 
-import java.time.LocalDateTime
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.JsonFieldType
-import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
-import org.springframework.restdocs.request.RequestDocumentation
-import org.springframework.restdocs.request.RequestDocumentation.pathParameters
-import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import com.mashup.shorts.api.ApiDocsTestBase
 import com.mashup.shorts.api.restdocs.util.PageHeaderSnippet
 import com.mashup.shorts.api.restdocs.util.RestDocsUtils
-import com.mashup.shorts.domain.category.Category
-import com.mashup.shorts.domain.category.CategoryName
 import com.mashup.shorts.domain.hot.keyword.HotKeywordsRetrieveApi
 import com.mashup.shorts.domain.keyword.HotKeywordRetrieve
 import com.mashup.shorts.domain.keyword.KeywordRanking
-import com.mashup.shorts.domain.news.News
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 
@@ -58,94 +50,6 @@ class HotKeywordsRetrieveApiTest : ApiDocsTestBase() {
                             .description("키워드 시간대 ex) 2023-06-30T21:30:42"),
                         fieldWithPath("result.ranking").type(JsonFieldType.ARRAY)
                             .description("핫 키워드 순위 (1위 ~ 10위)")
-                    )
-                )
-            )
-    }
-
-    @Test
-    fun `핫 키워드로 뉴스 조회`() {
-        every {
-            hotKeywordRetrieve.retrieveDetailHotKeyword(
-                any(), any(), any(), any()
-            )
-        } returns (
-            listOf(
-                News(
-                    title = "Title~!",
-                    content = "Contents ",
-                    thumbnailImageUrl = "IMAGE LINK",
-                    newsLink = "NEWS LINK",
-                    press = "TYN",
-                    writtenDateTime = "2023.06.29. 오전 11:41",
-                    type = "HEADLINE",
-                    crawledCount = 1,
-                    category = Category(CategoryName.CULTURE)
-                ),
-                News(
-                    title = "Title~!",
-                    content = "Contents ",
-                    thumbnailImageUrl = "IMAGE LINK",
-                    newsLink = "NEWS LINK",
-                    press = "TYN",
-                    writtenDateTime = "2023.06.29. 오전 11:41",
-                    type = "HEADLINE",
-                    crawledCount = 1,
-                    category = Category(CategoryName.CULTURE)
-                ),
-            )
-        )
-
-        mockMvc.perform(
-            RestDocumentationRequestBuilders
-                .get("/v1/hot-keywords/{keyword}", "위원")
-                .param("targetDateTime", LocalDateTime.now().toString())
-                .param("cursorId", "0")
-                .param("size", "10")
-                .contentType(MediaType.APPLICATION_JSON)
-        ).andDo(MockMvcResultHandlers.print())
-            .andExpect(MockMvcResultMatchers.status().isOk)
-            .andDo(
-                MockMvcRestDocumentation.document(
-                    "핫 키워드로 뉴스 조회",
-                    RestDocsUtils.getDocumentRequest(),
-                    RestDocsUtils.getDocumentResponse(),
-                    PageHeaderSnippet.pageHeaderSnippet(),
-                    pathParameters(
-                        RequestDocumentation
-                            .parameterWithName("keyword")
-                            .description("<필수값> 키워드"),
-                    ),
-                    queryParameters(
-                        RequestDocumentation
-                            .parameterWithName("targetDateTime")
-                            .description("타입 : LocalDateTime, 조회할 날짜/시간 ex) 2023-06-30T21:30:42"),
-                        RequestDocumentation
-                            .parameterWithName("cursorId")
-                            .description("커서 아이디, 가장 마지막에 받은 id를 넣어주세요 (기본 값은 0으로 지정됩니다.)"),
-                        RequestDocumentation
-                            .parameterWithName("size")
-                            .description("<필수값> 페이징 사이즈(최대 20까지 허용합니다.)"),
-                    ),
-                    PayloadDocumentation.responseFields(
-                        fieldWithPath("status").type(JsonFieldType.NUMBER)
-                            .description("API 성공 여부"),
-                        fieldWithPath("result[].id").type(JsonFieldType.NUMBER)
-                            .description("뉴스 id"),
-                        fieldWithPath("result[].title").type(JsonFieldType.STRING)
-                            .description("뉴스 제목"),
-                        fieldWithPath("result[].thumbnailImageUrl").type(JsonFieldType.STRING)
-                            .description("뉴스 이미지 링크"),
-                        fieldWithPath("result[].newsLink").type(JsonFieldType.STRING)
-                            .description("뉴스 링크"),
-                        fieldWithPath("result[].press").type(JsonFieldType.STRING)
-                            .description("언론사"),
-                        fieldWithPath("result[].writtenDateTime").type(JsonFieldType.STRING)
-                            .description("작성 시각"),
-                        fieldWithPath("result[].type").type(JsonFieldType.STRING)
-                            .description("헤드라인 뉴스인지, 일반 뉴스인지"),
-                        fieldWithPath("result[].category").type(JsonFieldType.STRING)
-                            .description("카테고리"),
                     )
                 )
             )

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/newscard/MemberNewsCardRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/newscard/MemberNewsCardRetrieveApiTest.kt
@@ -128,7 +128,7 @@ class MemberNewsCardRetrieveApiTest : ApiDocsTestBase() {
 
         val response = mockMvc.perform(
             RestDocumentationRequestBuilders
-                .get("/v1/member-news-card/")
+                .get("/v1/member-news-card/saved")
                 .header(headerName, uniqueKey)
                 .param("cursorId", cursorId.toString())
                 .param("size", size.toString())

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/news/NewsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/news/NewsRetrieveApiTest.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.api.restdocs.news
 
+import java.time.LocalDateTime
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
@@ -9,13 +10,18 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.JsonFieldType
 import org.springframework.restdocs.payload.PayloadDocumentation
 import org.springframework.restdocs.request.RequestDocumentation
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import com.mashup.shorts.api.ApiDocsTestBase
 import com.mashup.shorts.api.restdocs.util.PageHeaderSnippet
+import com.mashup.shorts.api.restdocs.util.RestDocsUtils
 import com.mashup.shorts.api.restdocs.util.RestDocsUtils.getDocumentRequest
 import com.mashup.shorts.api.restdocs.util.RestDocsUtils.getDocumentResponse
+import com.mashup.shorts.domain.category.Category
+import com.mashup.shorts.domain.category.CategoryName
 import com.mashup.shorts.domain.news.NewsRetrieve
 import com.mashup.shorts.domain.home.news.NewsRetrieveApi
+import com.mashup.shorts.domain.news.News
 import com.mashup.shorts.domain.news.NewsRetrieveInfo
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
@@ -54,6 +60,93 @@ class NewsRetrieveApiTest : ApiDocsTestBase() {
                         PayloadDocumentation.fieldWithPath("status").type(JsonFieldType.NUMBER).description("API HTTP Status 값"),
                         PayloadDocumentation.fieldWithPath("result.newsLink").type(JsonFieldType.STRING).description("뉴스 링크"),
                         PayloadDocumentation.fieldWithPath("result.isSaved").type(JsonFieldType.BOOLEAN).description("뉴스 저장 여부")
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `핫 키워드로 뉴스 조회`() {
+        every {
+            newsRetrieve.retrieveByHotKeyword(
+                any(), any(), any(), any()
+            )
+        } returns (
+            listOf(
+                News(
+                    title = "Title~!",
+                    content = "Contents ",
+                    thumbnailImageUrl = "IMAGE LINK",
+                    newsLink = "NEWS LINK",
+                    press = "TYN",
+                    writtenDateTime = "2023.06.29. 오전 11:41",
+                    type = "HEADLINE",
+                    crawledCount = 1,
+                    category = Category(CategoryName.CULTURE)
+                ),
+                News(
+                    title = "Title~!",
+                    content = "Contents ",
+                    thumbnailImageUrl = "IMAGE LINK",
+                    newsLink = "NEWS LINK",
+                    press = "TYN",
+                    writtenDateTime = "2023.06.29. 오전 11:41",
+                    type = "HEADLINE",
+                    crawledCount = 1,
+                    category = Category(CategoryName.CULTURE)
+                ),
+            )
+            )
+
+        mockMvc.perform(
+            RestDocumentationRequestBuilders
+                .get("/v1/hot-keywords")
+                .param("keyword", "대통령")
+                .param("targetDateTime", LocalDateTime.now().toString())
+                .param("cursorId", "0")
+                .param("size", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andDo(MockMvcResultHandlers.print())
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andDo(
+                MockMvcRestDocumentation.document(
+                    "핫 키워드로 뉴스 조회",
+                    RestDocsUtils.getDocumentRequest(),
+                    RestDocsUtils.getDocumentResponse(),
+                    PageHeaderSnippet.pageHeaderSnippet(),
+                    RequestDocumentation.queryParameters(
+                        RequestDocumentation
+                            .parameterWithName("keyword")
+                            .description("키워드를 입력해주세요"),
+                        RequestDocumentation
+                            .parameterWithName("targetDateTime")
+                            .description("타입 : LocalDateTime, 조회할 날짜/시간 ex) 2023-06-30T21:30:42"),
+                        RequestDocumentation
+                            .parameterWithName("cursorId")
+                            .description("커서 아이디, 가장 마지막에 받은 id를 넣어주세요 (기본 값은 0으로 지정됩니다.)"),
+                        RequestDocumentation
+                            .parameterWithName("size")
+                            .description("<필수값> 페이징 사이즈(최대 20까지 허용합니다.)"),
+                    ),
+                    PayloadDocumentation.responseFields(
+                        PayloadDocumentation.fieldWithPath("status").type(JsonFieldType.NUMBER)
+                            .description("API 성공 여부"),
+                        PayloadDocumentation.fieldWithPath("result[].id").type(JsonFieldType.NUMBER)
+                            .description("뉴스 id"),
+                        PayloadDocumentation.fieldWithPath("result[].title").type(JsonFieldType.STRING)
+                            .description("뉴스 제목"),
+                        PayloadDocumentation.fieldWithPath("result[].thumbnailImageUrl").type(JsonFieldType.STRING)
+                            .description("뉴스 이미지 링크"),
+                        PayloadDocumentation.fieldWithPath("result[].newsLink").type(JsonFieldType.STRING)
+                            .description("뉴스 링크"),
+                        PayloadDocumentation.fieldWithPath("result[].press").type(JsonFieldType.STRING)
+                            .description("언론사"),
+                        PayloadDocumentation.fieldWithPath("result[].writtenDateTime").type(JsonFieldType.STRING)
+                            .description("작성 시각"),
+                        PayloadDocumentation.fieldWithPath("result[].type").type(JsonFieldType.STRING)
+                            .description("헤드라인 뉴스인지, 일반 뉴스인지"),
+                        PayloadDocumentation.fieldWithPath("result[].category").type(JsonFieldType.STRING)
+                            .description("카테고리"),
                     )
                 )
             )

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/news/NewsRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/news/NewsRetrieveApiTest.kt
@@ -100,7 +100,7 @@ class NewsRetrieveApiTest : ApiDocsTestBase() {
 
         mockMvc.perform(
             RestDocumentationRequestBuilders
-                .get("/v1/hot-keywords")
+                .get("/v1/news")
                 .param("keyword", "대통령")
                 .param("targetDateTime", LocalDateTime.now().toString())
                 .param("cursorId", "0")

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRetrieve.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/keyword/HotKeywordRetrieve.kt
@@ -1,56 +1,16 @@
 package com.mashup.shorts.domain.keyword
 
 import java.time.LocalDateTime
-import java.time.LocalTime
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import com.mashup.shorts.common.exception.ShortsBaseException
 import com.mashup.shorts.common.exception.ShortsErrorCode
-import com.mashup.shorts.domain.news.News
-import com.mashup.shorts.domain.news.NewsRepository
-import com.mashup.shorts.domain.newscard.NewsCardRepository
 
 @Service
 @Transactional(readOnly = true)
 class HotKeywordRetrieve(
-    private val newsRepository: NewsRepository,
-    private val newsCardRepository: NewsCardRepository,
     private val hotKeywordRepository: HotKeywordRepository,
 ) {
-
-    fun retrieveDetailHotKeyword(
-        targetDateTime: LocalDateTime,
-        keyword: String,
-        cursorId: Long,
-        size: Int,
-    ): List<News> {
-        val newsCards = newsCardRepository.findByKeywordsLikeAndCursorId(
-            keyword = keyword,
-            cursorId = cursorId,
-            size = size
-        )
-
-        val newsIds = newsCards.map { index ->
-            index.multipleNews.split(", ").map { it.toLong() }
-        }
-
-        val firstDayOfMonth = LocalDateTime.of(
-            targetDateTime.toLocalDate(),
-            LocalTime.of(0, 0)
-        )
-        val lastDayOfMonth = LocalDateTime.of(
-            targetDateTime.toLocalDate(),
-            LocalTime.of(23, 59)
-        )
-
-        return newsRepository.loadNewsBundleByCursorIdAndTargetTime(
-            firstDayOfMonth,
-            lastDayOfMonth,
-            cursorId,
-            newsIds.flatten(),
-            size,
-        )
-    }
 
     fun retrieveHotKeywords(targetTime: LocalDateTime): KeywordRanking {
         val hotKeyword = hotKeywordRepository.findTopByOrderByIdDesc()

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepository.kt
@@ -12,8 +12,8 @@ interface NewsQueryDSLRepository {
     ): List<News>
 
     fun loadNewsBundleByCursorIdAndTargetTime(
-        firstDayOfMonth: LocalDateTime,
-        lastDayOfMonth: LocalDateTime,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
         cursorId: Long,
         newsIds: List<Long>,
         size: Int,

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsQueryDSLRepositoryImpl.kt
@@ -25,17 +25,17 @@ class NewsQueryDSLRepositoryImpl(
     }
 
     override fun loadNewsBundleByCursorIdAndTargetTime(
-        firstDayOfMonth: LocalDateTime,
-        lastDayOfMonth: LocalDateTime,
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
         cursorId: Long,
         newsIds: List<Long>,
         size: Int,
     ): List<News> {
         return queryFactory
             .selectFrom(news)
-            .where(news.id.`in`(newsIds))
             .where(news.id.gt(cursorId))
-            .where(news.createdAt.between(firstDayOfMonth, lastDayOfMonth))
+            .where(news.id.`in`(newsIds))
+            .where(news.createdAt.between(startDateTime, endDateTime))
             .limit(size.toLong())
             .fetch()
     }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/NewsRepository.kt
@@ -1,5 +1,6 @@
 package com.mashup.shorts.domain.news
 
+import java.time.LocalDateTime
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.category.Category
@@ -8,6 +9,11 @@ import com.mashup.shorts.domain.category.Category
 interface NewsRepository : JpaRepository<News, Long>, NewsQueryDSLRepository {
 
     fun findAllByCategory(category: Category): List<News>
-    fun findByTitleAndNewsLinkAndPress(title: String, newsLink: String, press: String): List<News>
     fun findTopByOrderByIdDesc(): News?
+
+    fun findAllByCreatedAtBetween(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
+    ): List<News>
+
 }


### PR DESCRIPTION
### 변경사항

- 키워드로 뉴스가 조회되지 않던 버그를 수정합니다.

- 키워드로 뉴스 카드 조회하기 API의 URI를 변경합니다.

- 저장한 오늘의 숏스 조회하기 API의 URI를 변경합니다.