### PR TITLE
홈 API에서 뉴스카드 조회 시 페이징을 제거하고, 뉴스카드를 랜덤하게 보여주도록 변경합니다.

### DIFF
--- a/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernewscard/MemberNewsCardRetrieveApi.kt
+++ b/shorts-api/src/main/kotlin/com/mashup/shorts/domain/my/membernewscard/MemberNewsCardRetrieveApi.kt
@@ -13,7 +13,9 @@ import com.mashup.shorts.common.response.ApiResponse
 import com.mashup.shorts.common.response.ApiResponse.Companion.success
 import com.mashup.shorts.domain.membernewscard.MemberNewsCardRetrieve
 import com.mashup.shorts.domain.my.membernewscard.dto.RetrieveHomeNewsCardResponse
+import com.mashup.shorts.domain.my.membernewscard.dto.RetrieveHomeNewsCardResponse.Companion.domainResponseFormToApiResponseForm
 import com.mashup.shorts.domain.my.membernewscard.dto.RetrieveSavedNewsCardResponse
+import com.mashup.shorts.domain.my.membernewscard.dto.RetrieveSavedNewsCardResponse.Companion.domainResponseFormToApiResponseForm
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 
@@ -25,27 +27,20 @@ class MemberNewsCardRetrieveApi(
 ) {
 
     /**
-     홈 조회 API
-     @Param : targetDateTime, cursorId, size
+    홈 조회 API
+    @Param : targetDateTime, cursorId, size
      */
     @Auth
     @GetMapping
     fun retrieveNewsCardByMember(
         @RequestParam targetDateTime: LocalDateTime,
-        @RequestParam(
-            defaultValue = "0",
-            required = false
-        ) @Min(0) @Max(Long.MAX_VALUE) cursorId: Long,
-        @RequestParam(required = true) @Min(1) @Max(20) size: Int,
     ): ApiResponse<List<RetrieveHomeNewsCardResponse>> {
         return success(
             OK,
-            RetrieveHomeNewsCardResponse.domainResponseFormToApiResponseForm(
+            domainResponseFormToApiResponseForm(
                 memberNewsCardRetrieve.retrieveNewsCardByMember(
                     member = AuthContext.getMember(),
                     targetDateTime = targetDateTime,
-                    cursorId = cursorId,
-                    size = size
                 )
             )
         )
@@ -53,7 +48,7 @@ class MemberNewsCardRetrieveApi(
 
     /**
     저장한 오늘의 숏스(뉴스카드) 조회 API
-     @Param : cursorId, size
+    @Param : cursorId, size
      */
     @Auth
     @GetMapping("/saved")
@@ -66,7 +61,7 @@ class MemberNewsCardRetrieveApi(
     ): ApiResponse<RetrieveSavedNewsCardResponse> {
         return success(
             OK,
-            RetrieveSavedNewsCardResponse.domainResponseFormToApiResponseForm(
+            domainResponseFormToApiResponseForm(
                 memberNewsCardRetrieve.retrieveSavedNewsCardByMember(
                     member = AuthContext.getMember(),
                     cursorId = cursorId,

--- a/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/newscard/MemberNewsCardRetrieveApiTest.kt
+++ b/shorts-api/src/test/kotlin/com/mashup/shorts/api/restdocs/member/newscard/MemberNewsCardRetrieveApiTest.kt
@@ -37,12 +37,10 @@ class MemberNewsCardRetrieveApiTest : ApiDocsTestBase() {
     fun `홈 조회`() {
         // ready
         val targetDateTime = LocalDateTime.now().minusDays(1)
-        val cursorId = 0L
-        val size = 10
         val uniqueKey = "uniqueKey"
         val headerName = "Authorization"
 
-        every { memberNewsCardRetrieve.retrieveNewsCardByMember(any(), any(), any(), any()) } returns (
+        every { memberNewsCardRetrieve.retrieveNewsCardByMember(any(), any()) } returns (
             listOf(
                 NewsCard(
                     category = Category(CategoryName.POLITICS),
@@ -59,8 +57,6 @@ class MemberNewsCardRetrieveApiTest : ApiDocsTestBase() {
                 .get("/v1/member-news-card")
                 .header(headerName, uniqueKey)
                 .param("targetDateTime", targetDateTime.toString())
-                .param("cursorId", cursorId.toString())
-                .param("size", size.toString())
                 .contentType(MediaType.APPLICATION_JSON)
         ).andDo(MockMvcResultHandlers.print())
 
@@ -78,12 +74,6 @@ class MemberNewsCardRetrieveApiTest : ApiDocsTestBase() {
                         RequestDocumentation
                             .parameterWithName("targetDateTime")
                             .description("요청 날짜 및 시간"),
-                        RequestDocumentation
-                            .parameterWithName("cursorId")
-                            .description("커서 아이디, 가장 마지막에 받은 id를 넣어주세요 (기본 값은 0으로 지정됩니다.)"),
-                        RequestDocumentation
-                            .parameterWithName("size")
-                            .description("<필수값> 페이징 사이즈(최대 20까지 허용합니다.)"),
                     ),
                     responseFields(
                         fieldWithPath("status").type(JsonFieldType.NUMBER)
@@ -97,7 +87,7 @@ class MemberNewsCardRetrieveApiTest : ApiDocsTestBase() {
                         fieldWithPath("result[].crawledDateTime").type(JsonFieldType.STRING)
                             .description("크롤링 된 시각 ex) 2023-06-30T21:30:42"),
 
-                    )
+                        )
                 )
             )
     }

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/common/util/StartEndDateTimeExtractor.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/common/util/StartEndDateTimeExtractor.kt
@@ -1,0 +1,23 @@
+package com.mashup.shorts.common.util
+
+import java.time.LocalDateTime
+
+object StartEndDateTimeExtractor {
+    fun extractStarDateTimeAndEndDateTime(
+        targetDateTime: LocalDateTime,
+    ): Pair<LocalDateTime, LocalDateTime> {
+        val startDateTime = targetDateTime
+            .withHour(targetDateTime.hour)
+            .withMinute(0)
+            .withSecond(0)
+            .withNano(0)
+
+        val endDateTime = targetDateTime
+            .withHour(targetDateTime.hour)
+            .withMinute(59)
+            .withSecond(59)
+            .withNano(59)
+
+        return Pair(startDateTime, endDateTime)
+    }
+}

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepository.kt
@@ -4,12 +4,16 @@ import java.time.LocalDateTime
 
 interface NewsCardQueryDSLRepository {
 
-    fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
-        cursorId: Long,
+    fun findNewsCardsByMemberFilteredNewsIds(
         startDateTime: LocalDateTime,
         endDateTime: LocalDateTime,
         categories: List<Long>,
-        size: Int,
+    ): List<NewsCard>
+
+    fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
+        categories: List<Long>,
     ): List<NewsCard>
 
     fun findSavedNewsCardsByNewsCardIds(

--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/newscard/NewsCardQueryDSLRepositoryImpl.kt
@@ -1,32 +1,44 @@
 package com.mashup.shorts.domain.newscard
 
+import java.time.LocalDateTime
+import org.springframework.stereotype.Repository
 import com.mashup.shorts.domain.category.QCategory.category
 import com.mashup.shorts.domain.newscard.QNewsCard.newsCard
 import com.querydsl.core.types.Predicate
 import com.querydsl.jpa.impl.JPAQueryFactory
-import org.springframework.stereotype.Repository
-import java.time.LocalDateTime
 
 @Repository
 class NewsCardQueryDSLRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : NewsCardQueryDSLRepository {
-    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
-        cursorId: Long,
+
+    override fun findNewsCardsByMemberFilteredNewsIds(
         startDateTime: LocalDateTime,
         endDateTime: LocalDateTime,
         categories: List<Long>,
-        size: Int,
     ): List<NewsCard> {
         return queryFactory
             .selectFrom(newsCard)
             .join(newsCard.category, category)
             .fetchJoin()
-            .where(cursorCondition(cursorId))
             .where(categoryCondition(categories))
             .where(newsCard.createdAt.between(startDateTime, endDateTime))
             .orderBy(newsCard.id.asc())
-            .limit(size.toLong())
+            .fetch()
+    }
+
+    override fun findNewsCardsByMemberFilteredNewsIdsAndCursorId(
+        startDateTime: LocalDateTime,
+        endDateTime: LocalDateTime,
+        categories: List<Long>,
+    ): List<NewsCard> {
+        return queryFactory
+            .selectFrom(newsCard)
+            .join(newsCard.category, category)
+            .fetchJoin()
+            .where(categoryCondition(categories))
+            .where(newsCard.createdAt.between(startDateTime, endDateTime))
+            .orderBy(newsCard.id.asc())
             .fetch()
     }
 


### PR DESCRIPTION
홈 API에서 뉴스카드 조회 시 페이징을 제거하고, 뉴스카드를 랜덤하게 보여주도록 변경합니다.

특이사항 없습니다.