### PR TITLE
News 테이블 보조 인덱스를 추가하여 조회 시 성능을 개선합니다.

### DIFF
--- a/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/News.kt
+++ b/shorts-domain/src/main/kotlin/com/mashup/shorts/domain/news/News.kt
@@ -5,11 +5,17 @@ import com.mashup.shorts.domain.category.Category
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
+import jakarta.persistence.Index
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 
-@Table(name = "news")
+@Table(
+    name = "news",
+    indexes = [
+        Index(name = "news_index", columnList = "created_at"),
+    ]
+)
 @Entity
 class News(
 

--- a/shorts-domain/src/main/resources/db/V1_DDL.sql
+++ b/shorts-domain/src/main/resources/db/V1_DDL.sql
@@ -103,3 +103,6 @@ values ("WORLD", now(), now());
 
 insert into category(name, created_at, modified_at)
 values ("SCIENCE", now(), now());
+
+CREATE INDEX news_index ON news(created_at);
+ANALYZE TABLE news;


### PR DESCRIPTION
## 기존 문제 상황

![](https://github.com/K-Diger/K-Diger.github.io/assets/60564431/dbd5d34f-8329-42dd-b23d-848f96bb9cc0)

위 그림과 같이 키워드로 뉴스를 조회할 때 약 10초 ~ 13초가 소요되었습니다.

그 이유는 News 도메인의 레코드를 Full Scan하여 데이터를 반환했던 이유였습니다.

## 해결방안

[해결 과정 자세히 보기](https://k-diger.github.io/posts/JPA-Index/)

```kotlin
@Table(
    name = "news",
    indexes = [
        Index(name = "news_index", columnList = "created_at"),
    ]
)
```

위와 같이 News 도메인 내 보조 인덱스를 생성하고 

```sql
CREATE INDEX news_index ON news(created_at);
ANALYZE TABLE news;
```

위와 같이 MySQL에 보조 인덱스를 생성하여 인덱스를 사용하는 것으로 성능을 개선했습ㄴ디ㅏ.

## 인덱스 선정 기준

인덱스 컬럼을 선정한 기준은 다음과 같습니다.

- 되도록 중복되지 않는 컬럼
- 조회 시 정렬 조건으로 사용되는 컬럼

따라서 뉴스 조회 시 사용되는 createdAt을 보조 인덱스 컬럼으로 지정하였습니다.

## 성능 개선

![](https://github.com/K-Diger/K-Diger.github.io/assets/60564431/3198996e-f9f8-4188-9ce8-b2cc555d0d84)

위 그림과 같이 API 응답 속도가 기존 13초에서 1.3초가 소요되도록 성능이 개선되었습니다.